### PR TITLE
Fix bug when width/height are zero

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -299,10 +299,10 @@ exports.resizeArgs = function(options) {
     args.push('-strip');
   }
   if (opt.width || opt.height) {
-    if (opt.height === 0) opt.height = opt.width;
-    else if (opt.width === 0) opt.width = opt.height;
     args.push('-resize');
-    args.push(String(opt.width)+'x'+String(opt.height));
+    if (opt.height === 0) args.push(String(opt.width));
+    else if (opt.width === 0) args.push('x'+String(opt.height));
+    else args.push(String(opt.width)+'x'+String(opt.height));
   }
   opt.format = opt.format.toLowerCase();
   var isJPEG = (opt.format === 'jpg' || opt.format === 'jpeg');


### PR DESCRIPTION
The docs say that just one of width or height need to be specified to `resize`, but the end result is not as expected. When presented with a 1024x920 image, for example, and a resize for height 90, the image gets resized to 90x81. One would certainly expect to get a 100x90 image, instead.

This patch fixes that.
