### PR TITLE
Detailed identify

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -132,6 +132,7 @@ exports.identify = function(pathOrArgs, callback) {
           width: parseInt(geometry[0]),
           height: parseInt(geometry[1]),
           depth: parseInt(properties['Depth']),
+          quality: parseInt(properties['Quality']) / 100,
         };
       }
     }

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -128,6 +128,7 @@ exports.identify = function(pathOrArgs, callback) {
         result = parseIdentify(stdout);
         geometry = result['geometry'].split(/x/);
 
+        result.format = result.format.match(/\S*/)[0]
         result.width = parseInt(geometry[0]);
         result.height = parseInt(geometry[1]);
         result.depth = parseInt(result.depth);

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -97,9 +97,9 @@ function parseIdentify(input) {
       }
       if (comps.length < 2) {
         props.push(prop);
-        prop = prop[currentLine.split(':')[0].trim()] = {};
+        prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
       } else {
-        prop[comps[0].trim()] = comps[1].trim();
+        prop[comps[0].trim().toLowerCase()] = comps[1].trim().toLowerCase();
       }
       prevIndent = indent;
     }
@@ -120,20 +120,18 @@ exports.identify = function(pathOrArgs, callback) {
       throw new Error('first argument is missing the "data" member');
   }
   var proc = exec2(exports.identify.path, args, {timeout:120000}, function(err, stdout, stderr) {
-    var result;
+    var result, geometry;
     if (!err) {
       if (isCustom) {
         result = stdout;
       } else {
-        var properties = parseIdentify(stdout),
-            geometry = properties['Geometry'].split(/x/);
-        result = {
-          format: properties['Format'],
-          width: parseInt(geometry[0]),
-          height: parseInt(geometry[1]),
-          depth: parseInt(properties['Depth']),
-          quality: parseInt(properties['Quality']) / 100,
-        };
+        result = parseIdentify(stdout);
+        geometry = result['geometry'].split(/x/);
+
+        result.width = parseInt(geometry[0]);
+        result.height = parseInt(geometry[1]);
+        result.depth = parseInt(result.depth);
+        result.quality = parseInt(result.quality) / 100;
       }
     }
     callback(err, result);

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -132,7 +132,7 @@ exports.identify = function(pathOrArgs, callback) {
         result.width = parseInt(geometry[0]);
         result.height = parseInt(geometry[1]);
         result.depth = parseInt(result.depth);
-        result.quality = parseInt(result.quality) / 100;
+        if (result.quality !== undefined) result.quality = parseInt(result.quality) / 100;
       }
     }
     callback(err, result);

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -99,7 +99,7 @@ function parseIdentify(input) {
         props.push(prop);
         prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
       } else {
-        prop[comps[0].trim().toLowerCase()] = comps[1].trim().toLowerCase();
+        prop[comps[0].trim().toLowerCase()] = comps[1].trim()
       }
       prevIndent = indent;
     }

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -131,7 +131,7 @@ exports.identify = function(pathOrArgs, callback) {
           format: properties['Format'],
           width: parseInt(geometry[0]),
           height: parseInt(geometry[1]),
-          depth: properties['Depth'],
+          depth: parseInt(properties['Depth']),
         };
       }
     }


### PR DESCRIPTION
It would be nice to be able to retrieve the image compression quality for jpegs with identify, just like you can do with the imagemagick identify command line tool when providing the `-verbose` flag. While we're at it, the other details emitted by `identify -verbose` would be nice to have too.

This patch provides that.

(Sorry for filing a pull request identical to the issue I reported. I had reported it as a reminder to myself and wasn't able to figure out how to later attach the pull request to it.)
