### PR TITLE
Allow passing process options into convert, not just timeout

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -241,17 +241,18 @@ exports.readMetadata = function(path, callback) {
 }
 
 exports.convert = function(args, procopts, callback) {
-  if (typeof timeout === 'function') {
-    callback = timeout;
-    timeout = 0;
-  } else if (typeof timeout !== 'number') {
-    timeout = 0;
-  }
-  if (typeof procopts != 'object') {
-    var timeout = procopts;
+  if (typeof procopts === 'function') {
+    callback = procopts;
     procopts = {};
-    if (timeout && (timeout = parseInt(timeout)) > 0 && !isNaN(timeout))
-      procopts.timeout = timeout;
+  }
+  if (typeof procopts !== 'object') {
+    var timeout = procopts;
+    if (timeout && (timeout = parseInt(timeout)) > 0 && !isNaN(timeout)) {
+      timeout = timeout;
+    } else {
+      timeout = 0;
+    }
+    procopts = {timeout: timeout};
   }
   procopts.encoding = 'binary';
   

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -251,8 +251,7 @@ exports.convert = function(args, procopts, callback) {
     var timeout = procopts;
     procopts = {};
     if (timeout && (timeout = parseInt(timeout)) > 0 && !isNaN(timeout))
-      procopts.timeout: timeout;
-    }
+      procopts.timeout = timeout;
   }
   procopts.encoding = 'binary';
   

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -240,17 +240,23 @@ exports.readMetadata = function(path, callback) {
   });
 }
 
-exports.convert = function(args, timeout, callback) {
-  var procopt = {encoding: 'binary'};
+exports.convert = function(args, procopts, callback) {
   if (typeof timeout === 'function') {
     callback = timeout;
     timeout = 0;
   } else if (typeof timeout !== 'number') {
     timeout = 0;
   }
-  if (timeout && (timeout = parseInt(timeout)) > 0 && !isNaN(timeout))
-    procopt.timeout = timeout;
-  return exec2(exports.convert.path, args, procopt, callback);
+  if (typeof procopts != 'object') {
+    var timeout = procopts;
+    procopts = {};
+    if (timeout && (timeout = parseInt(timeout)) > 0 && !isNaN(timeout))
+      procopts.timeout: timeout;
+    }
+  }
+  procopts.encoding = 'binary';
+  
+  return exec2(exports.convert.path, args, procopts, callback);
 }
 exports.convert.path = 'convert';
 


### PR DESCRIPTION
I need to handle cases where the output image from convert() is greater than 500K, which means passing in a larger maxBuffer value. This change makes it possible to pass an options object with maxBuffer and/or timeout to convert().
