### PR TITLE
Added custom crop options

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -302,8 +302,8 @@ exports.crop = function (options, callback) {
             resizeTo  = (dSrc < dDst) ? ''+t.opt.width+'x' : 'x'+t.opt.height;
         args = args.concat([
           '-resize', resizeTo,
-          '-gravity', 'Center',
-          '-crop', ''+t.opt.width + 'x' + t.opt.height + '+0+0',
+          '-gravity', t.opt.gravity,
+          '-crop', ''+t.opt.width + 'x' + t.opt.height + '+' + t.opt.top + '+' + t.opt.left,
           '+repage'
         ]);
         ignoreArg = false;
@@ -327,6 +327,9 @@ exports.resizeArgs = function(options) {
     colorspace: null,
     width: 0,
     height: 0,
+    gravity: 'NorthWest',
+    top: 0,
+    left: 0,
     strip: true,
     filter: 'Lagrange',
     sharpening: 0.2,


### PR DESCRIPTION
You can set 'gravity' type, with default of 'NorthWest' (makes cropping easier in my mind).
You can set 'top' and 'left' proprieties, so you can start cropping further form default position.  
