### PR TITLE
removed sys = require("sys")

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -1,5 +1,4 @@
-var sys = require('sys'),
-    childproc = require('child_process'),
+var childproc = require('child_process'),
     EventEmitter = require('events').EventEmitter;
 
 


### PR DESCRIPTION
Hi

one of my scripts has a dependency to your node-imagemagick module. When trying to use again I found that it didn't work anymore because there is a require("sys") statement which causes an error. 'sys' has been moved to 'util' for recent node versions.

Anyway, the sys variable is not used anymore in node-imagemagick an hence can simply be removed as I did it for my local installation of it. 

Removing it from the repo of node-imagemagick would make node-csssprite work again out-of-the-box with a npm i -g node-imagemagick. So I kindly ask you to pull that change into. :-)

Anyway, many thanks for node-imagemagick which made my work a snap.

cheers
marc
