### PR TITLE
using -format for identify to get more robust results

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -9,7 +9,9 @@ function exec2(program, args, opts, callback) {
       code,
       i = 0,
       decoder = new StringDecoder(),
-      v = process.version.split('.')[1];
+      v = process.version.split('.'),
+      version_major = v[0],
+      version_minor = v[1];
 
   if (typeof opts === 'function') {
     callback = opts;
@@ -26,7 +28,7 @@ function exec2(program, args, opts, callback) {
 
   child.on('exit', function(c) {
     code = c;
-    if (++i >= 2 || v < 8) callback(err, out, code);
+    if (++i >= 2 || (version_major === 0 && version_minor < 8)) callback(err, out, code);
   });
 
   child.on('close', function() {

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -1,96 +1,36 @@
-var childproc = require('child_process'),
-    EventEmitter = require('events').EventEmitter;
+var spawn = require('child_process').spawn,
+    EventEmitter = require('events').EventEmitter,
+    StringDecoder = require('string_decoder').StringDecoder;
 
+// based on https://github.com/bahamas10/node-exec
+function exec2(program, args, opts, callback) {
+  var out = '',
+      err = '',
+      code,
+      i = 0,
+      decoder = new StringDecoder(),
+      v = process.version.split('.')[1];
 
-function exec2(file, args /*, options, callback */) {
-  var options = { encoding: 'utf8'
-                , timeout: 0
-                , maxBuffer: 500*1024
-                , killSignal: 'SIGKILL'
-                , output: null
-                };
-
-  var callback = arguments[arguments.length-1];
-  if ('function' != typeof callback) callback = null;
-
-  if (typeof arguments[2] == 'object') {
-    var keys = Object.keys(options);
-    for (var i = 0; i < keys.length; i++) {
-      var k = keys[i];
-      if (arguments[2][k] !== undefined) options[k] = arguments[2][k];
-    }
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = null;
   }
+  var child = spawn(program, args, opts);
 
-  var child = childproc.spawn(file, args);
-  var killed = false;
-  var timedOut = false;
+  child.stdout.on('data', function(data) {
+    out += decoder.write(data);
+  });
+  child.stderr.on('data', function(data) {
+    err += decoder.write(data);
+  });
 
-  var Wrapper = function(proc) {
-    this.proc = proc;
-    this.stderr = new Accumulator();
-    proc.emitter = new EventEmitter();
-    proc.on = proc.emitter.on.bind(proc.emitter);
-    this.out = proc.emitter.emit.bind(proc.emitter, 'data');
-    this.err = this.stderr.out.bind(this.stderr);
-    this.errCurrent = this.stderr.current.bind(this.stderr);
-  };
-  Wrapper.prototype.finish = function(err) {
-    this.proc.emitter.emit('end', err, this.errCurrent());
-  };
+  child.on('exit', function(c) {
+    code = c;
+    if (++i >= 2 || v < 8) callback(err, out, code);
+  });
 
-  var Accumulator = function(cb) {
-    this.stdout = {contents: ""};
-    this.stderr = {contents: ""};
-    this.callback = cb;
-
-    var limitedWrite = function(stream) {
-      return function(chunk) {
-        stream.contents += chunk;
-        if (!killed && stream.contents.length > options.maxBuffer) {
-          child.kill(options.killSignal);
-          killed = true;
-        }
-      };
-    };
-    this.out = limitedWrite(this.stdout);
-    this.err = limitedWrite(this.stderr);
-  };
-  Accumulator.prototype.current = function() { return this.stdout.contents; };
-  Accumulator.prototype.errCurrent = function() { return this.stderr.contents; };
-  Accumulator.prototype.finish = function(err) { this.callback(err, this.stdout.contents, this.stderr.contents); };
-
-  var std = callback ? new Accumulator(callback) : new Wrapper(child);
-
-  var timeoutId;
-  if (options.timeout > 0) {
-    timeoutId = setTimeout(function () {
-      if (!killed) {
-        child.kill(options.killSignal);
-        timedOut = true;
-        killed = true;
-        timeoutId = null;
-      }
-    }, options.timeout);
-  }
-
-  child.stdout.setEncoding(options.encoding);
-  child.stderr.setEncoding(options.encoding);
-
-  child.stdout.addListener("data", function (chunk) { std.out(chunk, options.encoding); });
-  child.stderr.addListener("data", function (chunk) { std.err(chunk, options.encoding); });
-
-  child.addListener("exit", function (code, signal) {
-    if (timeoutId) clearTimeout(timeoutId);
-    if (code === 0 && signal === null) {
-      std.finish(null);
-    } else {
-      var e = new Error("Command "+(timedOut ? "timed out" : "failed")+": " + std.errCurrent());
-      e.timedOut = timedOut;
-      e.killed = killed;
-      e.code = code;
-      e.signal = signal;
-      std.finish(e);
-    }
+  child.on('close', function() {
+    if (++i >= 2) callback(err, out, code);
   });
 
   return child;


### PR DESCRIPTION
I was having issues with filenames that contained spaces.

Here is the documentation of identify's format option. Could be helpful if for future additions.
http://www.imagemagick.org/script/escape.php
