### PR TITLE
Depend on "util" module instead of the deprecated "sys"

### DIFF
--- a/test-crop.js
+++ b/test-crop.js
@@ -1,4 +1,4 @@
-var sys = require('sys'),
+var util = require('util'),
     fs = require('fs'),
     im = require('./imagemagick');
 
@@ -12,12 +12,12 @@ im.crop({
   height: 900,
   quality: 1
 }, function(err, stdout, stderr){
-  if (err) return sys.error(err.stack || err);
-  
-  sys.puts('real time taken for convert: ' + (new Date() - timeStarted) + ' ms')
-  
+  if (err) return util.error(err.stack || err);
+
+  util.puts('real time taken for convert: ' + (new Date() - timeStarted) + ' ms')
+
   im.identify(['-format', '%b', path + '.cropped.jpg'], function(err, r){
     if (err) throw err;
-    sys.puts('size: ' + r.substr(0, r.length-2) + ' Bytes');
+    util.puts('size: ' + r.substr(0, r.length-2) + ' Bytes');
   })
 })

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-var sys = require('sys'),
+var util = require('util'),
     fs = require('fs'),
     im = require('./imagemagick');
 
@@ -6,23 +6,23 @@ var path = 'sample-images/jpeg5.jpg';
 var imdata = fs.readFileSync(path, 'binary');
 
 im.identify(path, function(err, features){
-  if (err) return sys.error(err.stack || err);
-  sys.puts('features: '+sys.inspect(features));
+  if (err) return util.error(err.stack || err);
+  util.puts('features: '+util.inspect(features));
 })
 
 im.identify({data:imdata}, function(err, features){
-  if (err) return sys.error(err.stack || err);
-  sys.puts('features: '+sys.inspect(features));
+  if (err) return util.error(err.stack || err);
+  util.puts('features: '+util.inspect(features));
 })
 
 im.readMetadata(path, function(err, metadata){
-  if (err) return sys.error(err.stack || err);
-  sys.puts('metadata: '+sys.inspect(metadata));
+  if (err) return util.error(err.stack || err);
+  util.puts('metadata: '+util.inspect(metadata));
 })
 
 im.readMetadata({data:imdata}, function(err, metadata){
-  if (err) return sys.error(err.stack || err);
-  sys.puts('metadata: '+sys.inspect(metadata));
+  if (err) return util.error(err.stack || err);
+  util.puts('metadata: '+util.inspect(metadata));
 })
 
 var timeStarted = new Date;
@@ -31,11 +31,11 @@ im.resize({
   dstPath: path+'.resized.jpg',
   width: 256
 }, function(err, stdout, stderr){
-  if (err) return sys.error(err.stack || err);
-  sys.puts('real time taken for convert: '+((new Date)-timeStarted)+' ms')
+  if (err) return util.error(err.stack || err);
+  util.puts('real time taken for convert: '+((new Date)-timeStarted)+' ms')
   im.identify(['-format', '%b', path+'.resized.jpg'], function(err, r){
     if (err) throw err;
-    sys.puts('size: '+r.substr(0,r.length-2)+' Bytes');
+    util.puts('size: '+r.substr(0,r.length-2)+' Bytes');
   })
 })
 
@@ -44,8 +44,8 @@ im.resize({
   srcData: imdata,
   width: 256
 }, function(err, stdout, stderr){
-  if (err) return sys.error(err.stack || err);
-  sys.puts('real time taken for convert (with buffers): '+((new Date)-timeStarted)+' ms');
+  if (err) return util.error(err.stack || err);
+  util.puts('real time taken for convert (with buffers): '+((new Date)-timeStarted)+' ms');
   fs.writeFileSync(path+'.resized-io.jpg', stdout, 'binary');
-  sys.puts('size: '+stdout.length+' Bytes');
+  util.puts('size: '+stdout.length+' Bytes');
 })


### PR DESCRIPTION
Otherwise, when using node-imagemagick in an application running on node 0.8, I'm getting:

```
~$ node Sites/myapp.ikr.xiag.ch/nodes/img/app.js 

sys.js:1
throw new Error(
      ^
Error: The "sys" module is now called "util".
    at sys.js:1:69
    at NativeModule.compile (node.js:602:5)
    at Function.NativeModule.require (node.js:570:18)
    at Function.Module._load (module.js:297:25)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
    at Object.<anonymous> (/Users/ikr/Sites/myapp.ikr.xiag.ch/nodes/img/node_modules/imagemagick/imagemagick.js:1:73)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
```
