### PR TITLE
Wait on `close` instead of `exit`.

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -79,7 +79,8 @@ function exec2(file, args /*, options, callback */) {
   child.stdout.addListener("data", function (chunk) { std.out(chunk, options.encoding); });
   child.stderr.addListener("data", function (chunk) { std.err(chunk, options.encoding); });
 
-  child.addListener("exit", function (code, signal) {
+  var version = process.versions.node.split('.');
+  child.addListener(version[0] == 0 && version[1] < 7 ? "exit" : "close", function (code, signal) {
     if (timeoutId) clearTimeout(timeoutId);
     if (code === 0 && signal === null) {
       std.finish(null);


### PR DESCRIPTION
If the version of Node.js is less than `0.7`, wait on a `"close"` event from the ImageMagick process instead of `"exit"`. As of `0.7`, the `exit` "fires when the child actually exits, `close` fires when all stdio streams have closed."

See:

https://groups.google.com/forum/#!topic/nodejs/agsTbL-fco0/discussion
