### PR TITLE
parseIdentify() : skip also lines containing only whitespace

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -110,8 +110,8 @@ function parseIdentify(input) {
 
   for (i in lines) {
     currentLine = lines[i];
-    if (currentLine.length > 0) {
-      indent = currentLine.search(/\S/);
+    indent = currentLine.search(/\S/);
+    if (indent >= 0) {
       comps = currentLine.split(': ');
       if (indent > prevIndent) indents.push(indent);
       while (indent < prevIndent && props.length) {


### PR DESCRIPTION
Hi,

identify output containing lines with only whitespace leads to an exception in line 156 (today's master). The stdout from identify contains:

```
Properties:
  date:create: 2012-10-17T09:08:35+02:00
  date:modify: 2012-10-17T09:08:35+02:00
  exif:Artist: Corbis
  exif:Compression: 6
  exif:YResolution: 72/1
  jpeg:colorspace: 2
  jpeg:sampling-factor: 1x1,1x1,1x1
  MicrosoftPhoto:Rating: 63
  rdf:Alt: 


  signature: c259218a328758e7fa45b1bb3451469f8745cbe8800b6c7f7f308c7d3b875ed1
  unknown: 4
  xmp:CreateDate: 2008-02-11T19:32:43.173Z
  xmp:Rating: 4
Profiles:
  Profile-exif: 5153 bytes
  Profile-xmp: 2895 bytes
```

I have removed some lines to shorten it, but this is only about the seemingly empty lines in the middle: they contain several tabs.

The failing image is one included by default with Windows7 (Koala.jpg). It is processed fine after the fix.
