### PR TITLE
Support arbitrary cropping rectangles with im.crop().

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ im.resize({
 ### crop(options, callback) ###
 Convenience function for resizing and cropping an image. _crop_ uses the resize method, so _options_ and _callback_ are the same. _crop_ uses _options.srcPath_, so make sure you set it :) Using only _options.width_ or _options.height_ will create a square dimensioned image.  Gravity can also be specified, it defaults to Center.   Available gravity options are [NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast]
 
+You can also specify the top and left coordinates of the crop rectangle within the image by specifying _top_ and _left_ in the options. These MUST be strings!! This is in accordance with ImageMagick's image geometric syntax. _top_ and _left_ each must begin with a _+_ or _-_ followed by an integer representing a pixel offset from the top-left of the original image.
+
 Example:
 
 ```javascript
@@ -149,6 +151,8 @@ im.crop({
   dstPath: 'cropped.jpg',
   width: 800,
   height: 600,
+  top: '+20',
+  left: '+30',
   quality: 1,
   gravity: "North"
 }, function(err, stdout, stderr){

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -325,7 +325,7 @@ exports.crop = function (options, callback) {
             args = args.concat(['-resize', resizeTo]);
         } else {
             // Since this is an arbitrary crop rectange, use -crop instead of -resize.
-            args = args.concat(['-crop', ''+t.opt.width + 'x' + t.opt.height + (t.opt.top ? t.opt.top : '+0') + (t.opt.left ? t.opt.left : '+0')]);
+            args = args.concat(['-crop', ''+t.opt.width + 'x' + t.opt.height + (t.opt.left ? t.opt.left : '+0') + (t.opt.top ? t.opt.top : '+0')]);
         }
 
         args = args.concat([

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -319,10 +319,17 @@ exports.crop = function (options, callback) {
             dDst      = t.opt.width / t.opt.height,
             resizeTo  = (dSrc < dDst) ? ''+t.opt.width+'x' : 'x'+t.opt.height,
             dGravity  = options.gravity ? options.gravity : "Center";
+
+        if(!t.opt.top && !t.opt.left) {
+            // Add -resize flag if this isn't an arbitrary crop rectangle.
+            args = args.concat(['-resize', resizeTo]);
+        } else {
+            // Since this is an arbitrary crop rectange, use -crop instead of -resize.
+            args = args.concat(['-crop', ''+t.opt.width + 'x' + t.opt.height + (t.opt.top ? t.opt.top : '+0') + (t.opt.left ? t.opt.left : '+0')]);
+        }
+
         args = args.concat([
-          '-resize', resizeTo,
           '-gravity', dGravity,
-          '-crop', ''+t.opt.width + 'x' + t.opt.height + '+0+0',
           '+repage'
         ]);
         ignoreArg = false;
@@ -346,6 +353,8 @@ exports.resizeArgs = function(options) {
     colorspace: null,
     width: 0,
     height: 0,
+    top: 0,
+    left: 0,
     strip: true,
     filter: 'Lagrange',
     sharpening: 0.2,


### PR DESCRIPTION
IM is sensitive to the order of arguments on the command line. There were 2 problems preventing cropping with an arbitrary rectangle:
1. `-resize` was being placed before `-crop` which makes everything hard to calculate. My changes remove `-resize` from the command line if `top` and `left` are present in the options passed to `crop()`.
2. The `crop` function's options object didn't accept any notion of `top` or `left` to specify the top-left coordinate within the image of the top-left of the crop rectangle. My changes allow this to happen and use them in the `crop` function.
