### PR TITLE
Fix parsing of identify

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -104,7 +104,7 @@ function parseIdentify(input) {
       props = [prop],
       prevIndent = 0,
       indents = [indent],
-      currentLine, comps, indent, i;
+      currentLine, comps, indent, i, propName;
 
   lines.shift(); //drop first line (Image: name.jpg)
 
@@ -113,15 +113,17 @@ function parseIdentify(input) {
     indent = currentLine.search(/\S/);
     if (indent >= 0) {
       comps = currentLine.split(': ');
-      if (indent > prevIndent) indents.push(indent);
-      while (indent < prevIndent && props.length) {
-        indents.pop();
-        prop = props.pop();
-        prevIndent = indents[indents.length - 1];
+      if(propName != 'histogram') {
+        if (indent > prevIndent) indents.push(indent);
+        while (indent < prevIndent && props.length) {
+          indents.pop();
+          prop = props.pop();
+          prevIndent = indents[indents.length - 1];
+        }
       }
       if (comps.length < 2) {
         props.push(prop);
-        prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
+        prop = prop[propName = currentLine.split(':')[0].trim().toLowerCase()] = {};
       } else {
         prop[comps[0].trim().toLowerCase()] = comps[1].trim()
       }


### PR DESCRIPTION
Histogram output of identify has started to align on ':' which causes
parseIdentify to fail for this section.
