### PR TITLE
Silence unnecessary console logging in crop()

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ im.resize({
 ```
 
 ### crop(options, callback) ###
-Convenience function for resizing and cropping an image. _crop_ uses the resize method, so _options_ and _callback_ are the same. _crop_ uses _options.srcPath_, so make sure you set it :) Using only _options.width_ or _options.height_ will create a square dimensioned image.  Gravity can also be specified, it defaults to Center.   Available gravity options are [NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast]
+Convenience function for resizing and cropping an image. _crop_ uses the resize method, so _options_ and _callback_ are the same. _crop_ uses _options.srcPath_, so make sure you set it :) Using both _options.width_ and _options.height_ will create a square-dimensioned image; using only _options.width_ or _options.height_ will create a proportionately-dimensioned image.  Gravity can also be specified; it defaults to Center.   Available gravity options are [NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast].
 
 Example:
 

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -297,7 +297,7 @@ exports.crop = function (options, callback) {
         args      = [];
     t.args.forEach(function (arg) {
       if (printNext === true){
-        console.log("arg", arg);
+        // console.log("arg", arg);
         printNext = false;
       }
       // ignoreArg is set when resize flag was found
@@ -305,12 +305,12 @@ exports.crop = function (options, callback) {
         args.push(arg);
       // found resize flag! ignore the next argument
       if (arg == '-resize'){
-        console.log("resize arg");
+        // console.log("resize arg");
         ignoreArg = true;
         printNext = true;
       }
       if (arg === "-crop"){
-        console.log("crop arg");
+        // console.log("crop arg");
         printNext = true;
       }
       // found the argument after the resize flag; ignore it and set crop options


### PR DESCRIPTION
`console.log()` statements seem unnecssary -- maybe development left-overs.

This also make the README's documentation of `crop()` options conform to what the options actually do (specifcally with respect to square-resizing or not).
