### PR TITLE
Prototype safe for loop fix

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -95,7 +95,7 @@ function exec2(file, args /*, options, callback */) {
   });
 
   return child;
-};
+}
 
 
 function parseIdentify(input) {
@@ -108,8 +108,9 @@ function parseIdentify(input) {
 
   lines.shift(); //drop first line (Image: name.jpg)
 
-  for (i in lines) {
+  for (i = 0; i < lines.length; i++) {
     currentLine = lines[i];
+    console.log(currentLine);
     indent = currentLine.search(/\S/);
     if (indent >= 0) {
       comps = currentLine.split(': ');
@@ -123,13 +124,13 @@ function parseIdentify(input) {
         props.push(prop);
         prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
       } else {
-        prop[comps[0].trim().toLowerCase()] = comps[1].trim()
+        prop[comps[0].trim().toLowerCase()] = comps[1].trim();
       }
       prevIndent = indent;
     }
   }
   return prop;
-};
+}
 
 exports.identify = function(pathOrArgs, callback) {
   var isCustom = Array.isArray(pathOrArgs),
@@ -280,7 +281,7 @@ exports.crop = function (options, callback) {
     throw new TypeError("No srcPath or data defined");
   if (!options.height && !options.width)
     throw new TypeError("No width or height defined");
-  
+
   if (options.srcPath){
     var args = options.srcPath;
   } else {

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -110,7 +110,6 @@ function parseIdentify(input) {
 
   for (i = 0; i < lines.length; i++) {
     currentLine = lines[i];
-    console.log(currentLine);
     indent = currentLine.search(/\S/);
     if (indent >= 0) {
       comps = currentLine.split(': ');


### PR DESCRIPTION
It's not safe to use for in loops since those loop all enumerable properties in the object’s prototype chain, custom native properties will unexpectedly be included in such iterations.
