### PR TITLE
Remove default `Lagrange` filter

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -347,7 +347,6 @@ exports.resizeArgs = function(options) {
     width: 0,
     height: 0,
     strip: true,
-    filter: 'Lagrange',
     sharpening: 0.2,
     customArgs: [],
     timeout: 0


### PR DESCRIPTION
The setting made this module incompatible with GraphicsMagick at least in
version 1.3.16, which is being shipped at least with Debian stable (6.0.6) and
Ubuntu 12.04 (LTS) and 12.10. We prefer GraphicsMagick with the ImageMagick
wrappers to ImageMagick itself because it is said to be more stable and
efficient. See http://www.graphicsmagick.org/
