### PR TITLE
Use extern package "imagemagick-identify-parser"

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -100,7 +100,7 @@ function exec2(file, args /*, options, callback */) {
 
 
 function parseIdentify(input) {
-  return imParse(input, {lowerCase: true});
+  return imParse(input, "lower");
 };
 
 exports.identify = function(pathOrArgs, callback) {

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -1,5 +1,6 @@
 var childproc = require('child_process'),
-    EventEmitter = require('events').EventEmitter;
+    EventEmitter = require('events').EventEmitter,
+    imParse = require('imagemagick-identify-parser');
 
 
 function exec2(file, args /*, options, callback */) {
@@ -99,36 +100,7 @@ function exec2(file, args /*, options, callback */) {
 
 
 function parseIdentify(input) {
-  var lines = input.split("\n"),
-      prop = {},
-      props = [prop],
-      prevIndent = 0,
-      indents = [indent],
-      currentLine, comps, indent, i;
-
-  lines.shift(); //drop first line (Image: name.jpg)
-
-  for (i in lines) {
-    currentLine = lines[i];
-    indent = currentLine.search(/\S/);
-    if (indent >= 0) {
-      comps = currentLine.split(': ');
-      if (indent > prevIndent) indents.push(indent);
-      while (indent < prevIndent && props.length) {
-        indents.pop();
-        prop = props.pop();
-        prevIndent = indents[indents.length - 1];
-      }
-      if (comps.length < 2) {
-        props.push(prop);
-        prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
-      } else {
-        prop[comps[0].trim().toLowerCase()] = comps[1].trim()
-      }
-      prevIndent = indent;
-    }
-  }
-  return prop;
+  return imParse(input, {lowerCase: true});
 };
 
 exports.identify = function(pathOrArgs, callback) {

--- a/package.json
+++ b/package.json
@@ -7,4 +7,7 @@
                   , "url"  : "http://github.com/rsms/node-imagemagick.git" }
 , "engine"      : ["node >=0.6"]
 , "main"        : "imagemagick"
+, "dependencies": {
+  "imagemagick-identify-parser": ">= 0.0.4"
+}
 }


### PR DESCRIPTION
The imagemagick-identify-parser provides a more robust and legible parser for ImageMagick/GraphicsMagick output.

WARNING: This pull request defines a dependency on a yet unreleased version of `imagemagick-identify-parser` (in which I added the capability to lower-case key names). Please only merge & publish after that package is released.
