### PR TITLE
Do not allow lines of identify output containing whitespace only to crash the whole show

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -120,8 +120,12 @@ function parseIdentify(input) {
         prevIndent = indents[indents.length - 1];
       }
       if (comps.length < 2) {
-        props.push(prop);
-        prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
+        // Don't allow bad lines of output, as seen in the rdf property, to
+        // crash the whole show. Make sure there is a : present
+        if (currentLine.indexOf(':') !== -1) {
+          props.push(prop);
+          prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
+        }
       } else {
         prop[comps[0].trim().toLowerCase()] = comps[1].trim()
       }


### PR DESCRIPTION
Do not allow lines of identify output containing whitespace only to crash the whole show. Make sure there is a : present. Example of output that crashes when identify outputs lines containing whitespace only:

(I have added | marks to show where the whitespace ends. The | marks are
not in the actual output of identify.)

```
    rdf:Alt: |
     |
    |
    signature: a42e682fbf3b7a4aa29577935f6deed66e7a3e688a3edb8e3a0ccc7aad21d
```

My patch is to ignore lines with no : at all in them. Otherwise all properties encountered before this point, including the format property, are lost, and code in the imagemagick module that assumes there is a format property crashes.

I have attached the JPEG image that caused this result although I don't know whether github will regenerate it and lose the RDF property. I've seen this crash before, and now I know it relates to parseIdentify becoming confused, so if I spot other examples I'll track those down and patch them as well.

![acfhorizontallogo](https://f.cloud.github.com/assets/32125/335305/d644f2c0-9c88-11e2-936a-ece5bb39fb68.jpg)
