### PR TITLE
Fixed "for(i in lines)", checking for hasOwnProperty to avoid conflicts

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -104,12 +104,12 @@ function parseIdentify(input) {
       props = [prop],
       prevIndent = 0,
       currentLine, comps, indent, i,
-	  indents = [indent];
+      indents = [indent];
 
   lines.shift(); //drop first line (Image: name.jpg)
 
   for (i in lines) {
-	if(lines.hasOwnProperty(i)) {
+    if(lines.hasOwnProperty(i)) {
       currentLine = lines[i];
       indent = currentLine.search(/\S/);
       if (indent >= 0) {

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -103,29 +103,31 @@ function parseIdentify(input) {
       prop = {},
       props = [prop],
       prevIndent = 0,
-      indents = [indent],
-      currentLine, comps, indent, i;
+      currentLine, comps, indent, i,
+	  indents = [indent];
 
   lines.shift(); //drop first line (Image: name.jpg)
 
   for (i in lines) {
-    currentLine = lines[i];
-    indent = currentLine.search(/\S/);
-    if (indent >= 0) {
-      comps = currentLine.split(': ');
-      if (indent > prevIndent) indents.push(indent);
-      while (indent < prevIndent && props.length) {
-        indents.pop();
-        prop = props.pop();
-        prevIndent = indents[indents.length - 1];
+	if(lines.hasOwnProperty(i)) {
+      currentLine = lines[i];
+      indent = currentLine.search(/\S/);
+      if (indent >= 0) {
+        comps = currentLine.split(': ');
+        if (indent > prevIndent) indents.push(indent);
+        while (indent < prevIndent && props.length) {
+          indents.pop();
+          prop = props.pop();
+          prevIndent = indents[indents.length - 1];
+        }
+        if (comps.length < 2) {
+          props.push(prop);
+          prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
+        } else {
+          prop[comps[0].trim().toLowerCase()] = comps[1].trim()
+        }
+        prevIndent = indent;
       }
-      if (comps.length < 2) {
-        props.push(prop);
-        prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
-      } else {
-        prop[comps[0].trim().toLowerCase()] = comps[1].trim()
-      }
-      prevIndent = indent;
     }
   }
   return prop;


### PR DESCRIPTION
I've added an `if` to check if `for..in` is providing array values and not inherited values, like described [here](http://stackoverflow.com/a/4261096)
