### PR TITLE
Fix pasring xml values in identify

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -156,14 +156,18 @@ exports.identify = function(pathOrArgs, callback) {
       if (isCustom) {
         result = stdout;
       } else {
-        result = parseIdentify(stdout);
-        geometry = result['geometry'].split(/x/);
+        try {
+          result = parseIdentify(stdout);
+          geometry = result['geometry'].split(/x/);
 
-        result.format = result.format.match(/\S*/)[0]
-        result.width = parseInt(geometry[0]);
-        result.height = parseInt(geometry[1]);
-        result.depth = parseInt(result.depth);
-        if (result.quality !== undefined) result.quality = parseInt(result.quality) / 100;
+          result.format = result.format.match(/\S*/)[0]
+          result.width = parseInt(geometry[0]);
+          result.height = parseInt(geometry[1]);
+          result.depth = parseInt(result.depth);
+          if (result.quality !== undefined) result.quality = parseInt(result.quality) / 100;
+        } catch (ex) {
+            return callback(ex);
+        }
       }
     }
     callback(err, result);

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -110,6 +110,10 @@ function parseIdentify(input) {
 
   for (i in lines) {
     currentLine = lines[i];
+    // Skip xml multiline value. Found on http://beta.images.theglobeandmail.com/media/mobile/images/iphone.icon.highres.png.
+    if (/\s*</i.test(currentLine)) {
+      continue;
+    }
     indent = currentLine.search(/\S/);
     if (indent >= 0) {
       comps = currentLine.split(': ');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { "name"        : "imagemagick"
 , "description" : "A wrapper around the imagemagick cli"
-, "version"     : "0.1.3"
+, "version"     : "0.1.4"
 , "author"      : "Rasmus Andersson <http://rsms.me/>"
 , "licenses"    : ["MIT"]
 , "repository"  : { "type" : "git"


### PR DESCRIPTION
On image:
http://beta.images.theglobeandmail.com/media/mobile/images/iphone.icon.highres.png
got values to parse:

```
    Software: Adobe Fireworks CS3
    XML:com.adobe.xmp: <?xpacket begin="   " id="W5M0MpCehiHzreSzNTczkc9d"?>
<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.0-c060 61.134777, 2010/02/12-17:32:00        ">
   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
      <rdf:Description rdf:about=""
            xmlns:xmp="http://ns.adobe.com/xap/1.0/">
         <xmp:CreatorTool>Adobe Fireworks CS5 11.0.0.484 Macintosh</xmp:CreatorTool>
         <xmp:CreateDate>2010-10-18T17:05:17Z</xmp:CreateDate>
         <xmp:ModifyDate>2010-12-21T19:56:18Z</xmp:ModifyDate>
      </rdf:Description>
      <rdf:Description rdf:about=""
            xmlns:dc="http://purl.org/dc/elements/1.1/">
         <dc:format>image/png</dc:format>
      </rdf:Description>
   </rdf:RDF>
</x:xmpmeta>
```

`parseIdentify` function think `<x:xmpmeta`  is new document root and skips previous data.

Fast fix simply ignore xml tag lines.
