### PR TITLE
Please update this code.

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -153,13 +153,17 @@ exports.identify = function(pathOrArgs, callback) {
         result = stdout;
       } else {
         result = parseIdentify(stdout);
-        geometry = result['geometry'].split(/x/);
+        if(result['geometry'] !== undefined){
+            geometry = result['geometry'].split(/x/);
 
-        result.format = result.format.match(/\S*/)[0]
-        result.width = parseInt(geometry[0]);
-        result.height = parseInt(geometry[1]);
-        result.depth = parseInt(result.depth);
-        if (result.quality !== undefined) result.quality = parseInt(result.quality) / 100;
+            result.format = result.format.match(/\S*/)[0]
+            result.width = parseInt(geometry[0]);
+            result.height = parseInt(geometry[1]);
+            result.depth = parseInt(result.depth);
+            if (result.quality !== undefined) result.quality = parseInt(result.quality) / 100;
+        }else{
+            err = 'geometry for width and height is undefined';
+        }
       }
     }
     callback(err, result);


### PR DESCRIPTION
When I use `identify`  method, it gave me this error 'TypeError: Cannot call method 'split' of undefined'.
The problems is that result['geometry'] can be undefined. so It should be checked.

The result is below.

``` javascriopt
{ '</svg>': 
   { profiles: 
      { 'profile-8bim': '5354 bytes',
        'profile-iptc': '16 bytes',
        'unknown[2,0]': '',
        'caption[2,120]': '' } },
  artifacts: { filename: 'downloadFolder/1331_4jth358', verbose: 'true' },
  tainted: 'False',
  filesize: '71KB',
  'number pixels': '116K',
  'pixels per second': '0B',
  'user time': '0.000u',
  'elapsed time': '0:01.000',
  version: 'ImageMagick 6.8.0-10 2013-03-03 Q16 http://www.imagemagick.org' }
```

There is no geometry property in result. so it can't know the width and height of the image.
Please change the source code I give u, or you can fix it better.
Thank you.
