### PR TITLE
add 'aspect ratio' to the resize documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ function(err, stdout){
 
 ### resize(options, callback(err, stdout, stderr))
 
-Convenience function for resizing an image, modelled on top of `convert`.
+Convenience function for resizing an image, modelled on top of `convert`. 
+
+Because IM preserves the aspect ratio of an image, the area provided in the 'options' argument is not the final size of the image, but the maximum size for the image.
 
 The `options` argument have the following default values:
 


### PR DESCRIPTION
Added information about IM's preservation of 'aspect ratio' when resizing images. 
