### PR TITLE
Fix parseIdentify

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -121,7 +121,8 @@ function parseIdentify(input) {
       }
       if (comps.length < 2) {
         props.push(prop);
-        prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
+        if(currentLine.indexOf(':')>=0)
+            prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
       } else {
         prop[comps[0].trim().toLowerCase()] = comps[1].trim()
       }

--- a/imagemagick.js
+++ b/imagemagick.js
@@ -122,7 +122,7 @@ function parseIdentify(input) {
       if (comps.length < 2) {
         props.push(prop);
         if(currentLine.indexOf(':')>=0)
-            prop = prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
+            prop[currentLine.split(':')[0].trim().toLowerCase()] = {};
       } else {
         prop[comps[0].trim().toLowerCase()] = comps[1].trim()
       }


### PR DESCRIPTION
parseIdentify causes split error in "geometry = result['geometry'].split(/x/)"
because it not parse correctly
