### PR TITLE
Fix errant search method call

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -110,7 +110,7 @@ function parseIdentify(input) {
 
   for (i in lines) {
     currentLine = lines[i];
-    indent = currentLine.search(/\S/);
+    indent = typeof currentLine.search === 'function' ? indent = currentLine.search(/\S/) : -1;
     if (indent >= 0) {
       comps = currentLine.split(': ');
       if (indent > prevIndent) indents.push(indent);


### PR DESCRIPTION
This fixes a pesky missing method "search" error when reading beyond the end of the imagemagick input.
