### PR TITLE
No result geometry fix

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -153,12 +153,19 @@ exports.identify = function(pathOrArgs, callback) {
         result = stdout;
       } else {
         result = parseIdentify(stdout);
-        geometry = result['geometry'].split(/x/);
 
-        result.format = result.format.match(/\S*/)[0]
-        result.width = parseInt(geometry[0]);
-        result.height = parseInt(geometry[1]);
-        result.depth = parseInt(result.depth);
+        if (result.format) {
+          result.format = result.format.match(/\S*/)[0];
+        }
+
+        if (result['geometry']) {
+          geometry = result['geometry'].split(/x/);
+          result.width = parseInt(geometry[0]);
+          result.height = parseInt(geometry[1]);
+        }
+        if (result.depth) {
+          result.depth = parseInt(result.depth);
+        }
         if (result.quality !== undefined) result.quality = parseInt(result.quality) / 100;
       }
     }


### PR DESCRIPTION
Node is crushing if result does not contain geometry.
