### PR TITLE
Export exec2 function for call with option

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -131,6 +131,10 @@ function parseIdentify(input) {
   return prop;
 };
 
+exports.exec = function(args, procopt, callback) {
+  return exec2(exports.convert.path, args, procopt, callback);
+}
+
 exports.identify = function(pathOrArgs, callback) {
   var isCustom = Array.isArray(pathOrArgs),
       isData,


### PR DESCRIPTION
node-imagemagick is limited buffer size by `maxBuffer` in  exec2.
I add exec function to exports so that call with options (maxBuffer, encoding, etc...).
