### PR TITLE
Add '-coalesce' option for animated gifs.

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -383,6 +383,9 @@ exports.resizeArgs = function(options) {
   if (opt.strip) {
     args.push('-strip');
   }
+  if (opt.format === 'gif') {
+    args.push('-coalesce');
+  }
   if (opt.width || opt.height) {
     args.push('-resize');
     if (opt.height === 0) args.push(String(opt.width));


### PR DESCRIPTION
The current implementation resizes GIF files with animation incorrectly. The most of resized gifs has broken animation, showing larger scenes for some frames. This pull request is identical to the following patch:
https://www.drupal.org/files/imagemagick-resize_animated_gifs-1802534-1.patch
